### PR TITLE
feat(TA-1034): add partitioned cookie configuration

### DIFF
--- a/test/web-service/__snapshots__/nginx-util.test.ts.snap
+++ b/test/web-service/__snapshots__/nginx-util.test.ts.snap
@@ -164,6 +164,53 @@ exports[`nginx-util > createConfigMap > Empty 1`] = `
 ]
 `;
 
+exports[`nginx-util > createConfigMap > Partitioned cookies config 1`] = `
+[
+  {
+    "apiVersion": "v1",
+    "data": {
+      "partitioned.conf": "server {
+    location /api/oidclogin {
+      proxy_cookie_path / "/; Partitioned";
+    }
+  }",
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+      "labels": {
+        "prunable": "true",
+      },
+      "name": "test-nginx-config-c88fe926-m8bk7f665d",
+    },
+  },
+]
+`;
+
+exports[`nginx-util > createConfigMap > Partitioned cookies config with multiple locations 1`] = `
+[
+  {
+    "apiVersion": "v1",
+    "data": {
+      "partitioned.conf": "server {
+    location /api/oidclogin {
+      proxy_cookie_path / "/; Partitioned";
+    }
+location /api/auth/login {
+      proxy_cookie_path / "/; Partitioned";
+    }
+  }",
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+      "labels": {
+        "prunable": "true",
+      },
+      "name": "test-nginx-config-c88fe926-5gf9f48485",
+    },
+  },
+]
+`;
+
 exports[`nginx-util > createConfigMap > Same site cookies config 1`] = `
 [
   {

--- a/test/web-service/nginx-util.test.ts
+++ b/test/web-service/nginx-util.test.ts
@@ -95,5 +95,23 @@ describe("nginx-util", () => {
       const results = Testing.synth(chart);
       expect(results).toMatchSnapshot();
     });
+
+    test("Partitioned cookies config", () => {
+      const chart = Testing.chart();
+      nginxUtil.createConfigMap(chart, {
+        usePartionedCookiesLocations: ["/api/oidclogin"],
+      });
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("Partitioned cookies config with multiple locations", () => {
+      const chart = Testing.chart();
+      nginxUtil.createConfigMap(chart, {
+        usePartionedCookiesLocations: ["/api/oidclogin", "/api/auth/login"],
+      });
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
## Problem

* [TA-1034](https://techfromsage.atlassian.net/browse/TA-1034)

On analysing Elevate's use of LTI.js, we identified that it requires third party cookies. The library has not yet been updated to change this particular feature.

In order for LTI launches to continue to work in Elevate (at least for Chrome-based browsers), we require a solution that allows these cookies to be processed in a PKCE workflow.

The current solution to this issue is [partioned cookies](https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies).

Elevate cannot support this at an LTI.js level, nor at the Express.js level so we must resort to a supporting configuration in nginx.

This new property will load a supporting nginx configuration. 