### PR TITLE
feat: improve pod disruption budget validation

### DIFF
--- a/e2e/rails-app.e2e.ts
+++ b/e2e/rails-app.e2e.ts
@@ -90,7 +90,7 @@ export class RubyOnRailsAppChart extends TalisChart {
       uptimeUrl: "None",
       includeIngress: false,
       image: `docker.io/redmine:${redmineVersion}`,
-      replicas: 1,
+      replicas: 2,
       release: redmineVersion,
       port: applicationPort,
       resources: commonResources,

--- a/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
+++ b/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
@@ -1151,7 +1151,7 @@ proxy_cookie_path / "/$cookie_path_patches";
           "type": "Resource",
         },
       ],
-      "minReplicas": 1,
+      "minReplicas": 2,
       "scaleTargetRef": {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -2636,7 +2636,7 @@ proxy_cookie_path / "/$cookie_path_patches";
           "type": "Resource",
         },
       ],
-      "minReplicas": 1,
+      "minReplicas": 2,
       "scaleTargetRef": {
         "apiVersion": "apps/v1",
         "kind": "Deployment",

--- a/examples/advanced-web-service/chart.ts
+++ b/examples/advanced-web-service/chart.ts
@@ -93,7 +93,7 @@ export class AdvancedWebServiceChart extends TalisChart {
 
       // Auto-scaling
       horizontalPodAutoscaler: {
-        minReplicas: 1,
+        minReplicas: 2,
         maxReplicas: 5,
         cpuTargetUtilization: 50,
       },

--- a/examples/simple-web-service/__snapshots__/main.test.ts.snap
+++ b/examples/simple-web-service/__snapshots__/main.test.ts.snap
@@ -111,7 +111,7 @@ exports[`Simple WebService example > Snapshot 1`] = `
       "name": "test-web-c883b2c8",
     },
     "spec": {
-      "replicas": 1,
+      "replicas": 2,
       "revisionHistoryLimit": 1,
       "selector": {
         "matchLabels": {

--- a/examples/simple-web-service/main.ts
+++ b/examples/simple-web-service/main.ts
@@ -28,7 +28,7 @@ export class SimpleWebServiceChart extends Chart {
       // Pod details
       image: "docker.io/bitnami/node-example:0.0.1",
       release: "0.0.1",
-      replicas: 1,
+      replicas: 2,
       resources: {
         requests: {
           cpu: Quantity.fromString("50m"),

--- a/test/web-service/web-service.test.ts
+++ b/test/web-service/web-service.test.ts
@@ -663,7 +663,7 @@ describe("WebService", () => {
     });
 
     test("It includes podDisruptionBudget by default", () => {
-      const results = synthWebService({ ...requiredProps, replicas: 1 });
+      const results = synthWebService({ ...requiredProps, replicas: 2 });
       const pdbs = results.filter((obj) => obj.kind === "PodDisruptionBudget");
       expect(pdbs).toHaveLength(1);
     });


### PR DESCRIPTION
https://techfromsage.atlassian.net/browse/PLT-1083

Problem: While upgrading EKS to Kubernetes 1.30 and 1.31 we ran into issues with Node Group upgrades as they couldn’t evict some Pods. We found the reason to be PodDisruptionBudget violations where PDB is configured with minAvailable: 1 while there is only 1 replica.

Fix: WebService construct validates that when PodDisruptionBudget is enabled, then Deployment’s min replicas is greater (but not equal) than PDB’s minAvailable. 